### PR TITLE
Add EPA adjusted AQI values.

### DIFF
--- a/model/model.proto
+++ b/model/model.proto
@@ -10,6 +10,7 @@ message Sensor {
     float latitude = 2;
     float longitude = 3;
     uint32 reading = 4;
+    uint32 epa_adjusted_reading = 5;
 }
 
 message Sensors {

--- a/server/update_data/model_pb2.py
+++ b/server/update_data/model_pb2.py
@@ -17,9 +17,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='model.proto',
   package='data',
   syntax='proto3',
-  serialized_options=b'Z%github.com/finiteloop/air/server/data\272\002\000',
+  serialized_options=b'\272\002\000',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0bmodel.proto\x12\x04\x64\x61ta\"J\n\x06Sensor\x12\n\n\x02id\x18\x01 \x01(\r\x12\x10\n\x08latitude\x18\x02 \x01(\x02\x12\x11\n\tlongitude\x18\x03 \x01(\x02\x12\x0f\n\x07reading\x18\x04 \x01(\r\"(\n\x07Sensors\x12\x1d\n\x07sensors\x18\x01 \x03(\x0b\x32\x0c.data.SensorB*Z%github.com/finiteloop/air/server/data\xba\x02\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0bmodel.proto\x12\x04\x64\x61ta\"h\n\x06Sensor\x12\n\n\x02id\x18\x01 \x01(\r\x12\x10\n\x08latitude\x18\x02 \x01(\x02\x12\x11\n\tlongitude\x18\x03 \x01(\x02\x12\x0f\n\x07reading\x18\x04 \x01(\r\x12\x1c\n\x14\x65pa_adjusted_reading\x18\x05 \x01(\r\"(\n\x07Sensors\x12\x1d\n\x07sensors\x18\x01 \x03(\x0b\x32\x0c.data.SensorB\x03\xba\x02\x00\x62\x06proto3'
 )
 
 
@@ -61,6 +61,13 @@ _SENSOR = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='epa_adjusted_reading', full_name='data.Sensor.epa_adjusted_reading', index=4,
+      number=5, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -74,7 +81,7 @@ _SENSOR = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=21,
-  serialized_end=95,
+  serialized_end=125,
 )
 
 
@@ -105,8 +112,8 @@ _SENSORS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=97,
-  serialized_end=137,
+  serialized_start=127,
+  serialized_end=167,
 )
 
 _SENSORS.fields_by_name['sensors'].message_type = _SENSOR

--- a/server/update_data/purpleair.py
+++ b/server/update_data/purpleair.py
@@ -29,8 +29,16 @@ def _parse_result(result):
     longitude = float(result["Lon"])
     stats = json.loads(result["Stats"])
     reading = aqi_from_pm(stats["v1"])
+    epa_adjusted_reading = aqi_from_pm(_apply_epa_adjustment(stats["v1"], int(result["humidity"])))
     return model_pb2.Sensor(
-        id=id, latitude=latitude, longitude=longitude, reading=reading)
+        id=id, latitude=latitude, longitude=longitude, reading=reading, epa_adjusted_reading=epa_adjusted_reading)
+
+
+def _apply_epa_adjustment(concentration, relative_humidity):
+    if concentration > 250:
+        return concentration
+    else:
+        return 0.534 * concentration - 0.0844 * relative_humidity + 5.604
 
 
 def aqi_from_pm(pm):


### PR DESCRIPTION
What I did:

- Added formula for doing EPA adjustment
- Added a field to the model to store the EPA adjusted value separately
_I didn't necessarily want to make that the new "main reading" since the EPA stuff only really applies to wildfire smoke, as opposed to smog or other types of PM2.5 pollution. Maybe make this an option in the client?_

What I didn't do:

- ~~Recompile the model with protobufs (I don't have any of that stuff set up, nor have I done that before)~~
(nevermind, today I learned a new thing... I'd appreciate a sanity check on it, though)

I figured I'd send you this code if you want to merge and/or rework it however you like.