### PR TITLE
Filter out Channel B readings

### DIFF
--- a/server/update_data/purpleair.py
+++ b/server/update_data/purpleair.py
@@ -21,7 +21,7 @@ def parse_json(data):
 
 
 def _parse_result(result):
-    if result.get("ParentID")
+    if result.get("ParentID"):
         # Channel B is a redundancy sensor on the same physical device as Channel A.
         # We could look up the location data through the ParentID, but the PurpleAir website
         # seems to filter out all Channel B devices.

--- a/server/update_data/purpleair.py
+++ b/server/update_data/purpleair.py
@@ -21,6 +21,11 @@ def parse_json(data):
 
 
 def _parse_result(result):
+    if result.get("ParentID")
+        # Channel B is a redundancy sensor on the same physical device as Channel A.
+        # We could look up the location data through the ParentID, but the PurpleAir website
+        # seems to filter out all Channel B devices.
+        raise Exception("Device is Channel B and does not have location information")
     if result.get("DEVICE_LOCATIONTYPE", "outside") != "outside":
         # Skip sensors that are inside
         raise Exception("Device is not outside")


### PR DESCRIPTION
Purple Air sensors have 2 "channels", which are individual lasers on the same physical device. The secondary ("Channel B") sensors don't have a "DEVICE_LOCATIONTYPE" field, so are all being treated as outdoors.

With a bit of a refactor, you could put all the sensors in a hash, and use the ParentID field to look up the correct location from the "Channel A" sensor, but it looks like the PurpleAir website just filters these out (i.e. doesn't show the B readings at all). They're from the exact same lat/long so they'll likely be on top / below the other data point anyways.