### PR TITLE
Update Reading.swift

### DIFF
--- a/client/swift/AQI/Reading.swift
+++ b/client/swift/AQI/Reading.swift
@@ -54,7 +54,7 @@ public class Reading: NSObject, MKAnnotation, Comparable {
     }
     
     public var lastUpdated: Date {
-        return Date(timeIntervalSince1970: Double(self._sensor.lastUpdated) / 1000.0)
+        return Date(timeIntervalSince1970: Double(self._sensor.lastUpdated))
     }
 
     public var subtitle: String? {


### PR DESCRIPTION
Looking at the change https://github.com/finiteloop/air-quality/commit/37b610111d530afebb31c1f1aadc4a6f40991797

Specifically: The sample data https://github.com/finiteloop/air-quality/commit/37b610111d530afebb31c1f1aadc4a6f40991797#diff-c2bc060634137df0c3e55c17f7d77c677946cb64f021e05034c563cee8c1da3aR32

I see the timestamp is of this format `1608141289` yet the code here on the client side is dividing by 1000. I think this division is no longer needed? I haven't tested personally as I don't have XCode properly setup -- but I think this will resolve the "50 years ago" bug.

See bug: https://imgur.com/gallery/IahUeSU